### PR TITLE
Update allowed URLs in manifest.json to fix logout

### DIFF
--- a/holochrome/manifest.json
+++ b/holochrome/manifest.json
@@ -41,6 +41,7 @@
         "notifications",
         "webRequest",
         "https://signin.aws.amazon.com/federation",
+        "https://*.signin.aws.amazon.com/oauth",
         "http://169.254.169.254/*",
         "https://console.aws.amazon.com/*",
         "https://aws.amazon.com/"


### PR DESCRIPTION
It appears AWS updated their logout sequence, so Holochrome is no longer
able to automatically log you out when switching accounts. The logout
URL now redirects you to something like
us-east-1.signin.aws.amazon.com/oauth, so adding that to the allowed
URLs re-enables automatically logging in.
