### PR TITLE
Removed superfluous URL match pattern

### DIFF
--- a/holochrome/manifest.json
+++ b/holochrome/manifest.json
@@ -20,7 +20,6 @@
     "content_scripts": [
         {
             "matches": [
-                "https://console.aws.amazon.com/*",
                 "https://*.console.aws.amazon.com/*"
             ],
             "js": [


### PR DESCRIPTION
Per the [Chrome developer page](https://developer.chrome.com/extensions/match_patterns) on match patterns, `"https://*.console.aws.amazon.com/*"` matches a superset of `"https://console.aws.amazon.com/*"`!

Should've fixed that in my last pull request. I'm sorry!
