### PR TITLE
Add better session timeout

### DIFF
--- a/holochrome/script.js
+++ b/holochrome/script.js
@@ -60,6 +60,7 @@ var request = function(url, callback, isEvent, attempts=0) {
 var getSigninToken = function(creds, isEvent) {
   var signinTokenUrl = federationUrlBase
                         + '?Action=getSigninToken'
+                        + '&SessionDuration=43200'
                         + '&Session=' + encodeURIComponent(JSON.stringify(creds));
   var onComplete = function(response) {
       response = JSON.parse(response);

--- a/test/test.js
+++ b/test/test.js
@@ -42,7 +42,7 @@ describe('holochrome', function(){
 
     expect(requests.length).toBe(numAttempts+3);
     expect(requests[numAttempts+2].method).toBe('GET');
-    expect(requests[numAttempts+2].url).toBe('https://signin.aws.amazon.com/federation?Action=getSigninToken&Session=%7B%22sessionId%22%3A%22omg%22%2C%22sessionKey%22%3A%22such%22%2C%22sessionToken%22%3A%22wow%22%7D');
+    expect(requests[numAttempts+2].url).toBe('https://signin.aws.amazon.com/federation?Action=getSigninToken&SessionDuration=43200&Session=%7B%22sessionId%22%3A%22omg%22%2C%22sessionKey%22%3A%22such%22%2C%22sessionToken%22%3A%22wow%22%7D');
     requests[numAttempts+2].respond(200, {}, JSON.stringify({
       'SigninToken':'token'
     }));


### PR DESCRIPTION
Leverages usage of the parameters of the federation API to increase session timeout (MVP)

Docs for reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html